### PR TITLE
DEVOPS 971: use new gpg key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5.0.0
         with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_ARTIFACT_SIGNING_KEY }}
+          passphrase: ${{ secrets.GPG_ARTIFACT_SIGNING_PASSPHRASE }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4.2.0


### PR DESCRIPTION
New public key: https://packages.traceable.ai/public-key.asc