### PR TITLE
fix: Nil pointer of string when logging is not configured for api gateway stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ brew install goreleaser
 ```
 2. Make dev build
 ```shell
-goreleaser build --snapshot
+goreleaser build --snapshot --clean
 ```
 3. Update `~/.terraformrc` with the location of the build
 GoReleaser will publish artifacts for all the different runtimes. Find the correct build and add it's path in the above 

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -315,16 +315,21 @@ func getLogGroupNamesRestApisHelper(
 		}
 		for _, stage := range res.Item {
 			stageName := *(stage.StageName)
+			tflog.Debug(ctx, fmt.Sprintf("Polling details for %s api %s stage", apiId, stageName))
 			apiIdWithStageName := strings.Join([]string{apiId, stageName}, "/")
 			if len(apiStages) > 0 && contains(apiStages, stageName) == exclude {
 				continue
 			}
 			if settings, ok := stage.MethodSettings["*/*"]; ok {
-				if *(settings.LoggingLevel) == "INFO" && settings.DataTraceEnabled {
+				var logLevel string
+				if settings.LoggingLevel != nil {
+					logLevel = *settings.LoggingLevel
+				}
+				if logLevel == "INFO" && settings.DataTraceEnabled {
 					logGroupNames = append(logGroupNames, getExecutionLogGroupName(apiId, stageName))
-				} else if *(settings.LoggingLevel) == "INFO" {
+				} else if logLevel == "INFO" {
 					mapDiagnostics.addError(FullRequestAndResponseLogNotEnabled.new(), apiIdWithStageName)
-				} else if *(settings.LoggingLevel) == "ERROR" {
+				} else if logLevel == "ERROR" {
 					mapDiagnostics.addError(ExecutionLogErrorOnly.new(), apiIdWithStageName)
 				} else {
 					mapDiagnostics.addError(ExecutionLogNotEnabled.new(), apiIdWithStageName)


### PR DESCRIPTION
Found this on QE testing of 2.5.2 release